### PR TITLE
Fix es6 build and add Steal compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "watch": "babel --watch -d lib/ src/",
     "jshint": "jshint src/. test/. --config",
     "mocha": "mocha test/ --compilers js:babel-core/register --recursive --timeout 5000",
-    "test": "npm run jshint && npm run mocha"
+    "test": "npm run compile && npm run jshint && npm run mocha"
   },
   "directories": {
     "lib": "lib"

--- a/src/sockets/index.js
+++ b/src/sockets/index.js
@@ -19,4 +19,7 @@ function socketio(socket) {
   return base(socket);
 }
 
-export { socketio, base as primus };
+export default {
+  socketio,
+  primus: base
+};

--- a/test/base.js
+++ b/test/base.js
@@ -78,5 +78,13 @@ module.exports = function(service) {
         done();
       });
     });
+
+    it('is built correctly', () => {
+      assert.equal(typeof require('../lib/client'), 'function');
+      assert.equal(typeof require('../lib/client').jquery, 'function');
+      assert.equal(typeof require('../lib/client').request, 'function');
+      assert.equal(typeof require('../lib/client').socketio, 'function');
+      assert.equal(typeof require('../lib/client').primus, 'function');
+    });
   });
 };


### PR DESCRIPTION
@daffl  

I've fixed the exports on src/sockets/index.js so that the Babel build does not strip socketio and primus from the final export.  This line in `client.js`

```js
Object.assign(client, rest, sockets);
```

was getting compiled to

```js
_extends(client, _index2.default, _index4.default);
```

But `_index4.default` was `undefined`.  Modifying the exports fixed the issue.

I've also added the `events` and `querystring` core node modules to the dependencies, so they get included with the build.  This lets Steal use the main package instead of the `dist/feathers.js` file.

Finally, I've added /index to a couple of imports because Steal was looking for a file called ./rest.js instead of ./rest/index.  The same goes for ./sockets.

Closes #12 .