### PR TITLE
Change variable naming from "app" to "feathersClient"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,10 +24,10 @@ In the browser a client that connects to the local server via websockets can be 
 <script type="text/javascript" src="//cdn.rawgit.com/feathersjs/feathers-client/v1.1.0/dist/feathers.js"></script>
 <script type="text/javascript">
   var socket = io();
-  var app = feathers()
+  var feathersClient = feathers()
     .configure(feathers.hooks())
     .configure(feathers.socketio(socket));
-  var todoService = app.service('todos');
+  var todoService = feathersClient.service('todos');
   
   todoService.on('created', function(todo) {
     console.log('Someone created a todo', todo);

--- a/readme.md
+++ b/readme.md
@@ -24,10 +24,10 @@ In the browser a client that connects to the local server via websockets can be 
 <script type="text/javascript" src="//cdn.rawgit.com/feathersjs/feathers-client/v1.1.0/dist/feathers.js"></script>
 <script type="text/javascript">
   var socket = io();
-  var feathersClient = feathers()
+  var client = feathers()
     .configure(feathers.hooks())
     .configure(feathers.socketio(socket));
-  var todoService = feathersClient.service('todos');
+  var todoService = client.service('todos');
   
   todoService.on('created', function(todo) {
     console.log('Someone created a todo', todo);


### PR DESCRIPTION
This should help people like me who could get confused by having "feathersClient" called "app" but not being able to use it as "app" in feathers (not client) or express.

Regarding: https://github.com/feathersjs/feathers-client/issues/102