### PR TITLE
Remove reference to typings/index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference path="typings/index.d.ts" />
-
 import events = require('events');
 
 export class FeathersApp {


### PR DESCRIPTION
### Summary

Typings installs our dependencies in the project folder instead of the feathers-client folder, so we don't need this reference to the local typings. 
