### PR TITLE
Add feathers-errors to the client export

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,10 +1,18 @@
 import feathers from 'feathers/client';
 import hooks from 'feathers-hooks';
+import errors from 'feathers-errors';
 import authentication from 'feathers-authentication-client';
 import rest from 'feathers-rest/client';
 import socketio from 'feathers-socketio/client';
 import primus from 'feathers-primus/client';
 
-Object.assign(feathers, { socketio, primus, rest, hooks, authentication });
+Object.assign(feathers, {
+  socketio,
+  primus,
+  rest,
+  hooks,
+  authentication,
+  errors
+});
 
 export default feathers;


### PR DESCRIPTION
It is already included so we may as well also export it explicitly.