### PR TITLE
Add default export to TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,27 +1,43 @@
-import events = require('events');
-
-interface FeathersApp {
-  // Authentication.
-  authenticate(options: any) :Promise<any>;
-  logout(): void;
-  get(type: string): any;
-
-  // Services.
-  service<T>(name: string): FeathersService<T>;
+declare module 'feathers-client' {
+  import events = require('events');
   
-  configure(fn: () => void): FeathersApp;
-}
+  interface FeathersApp {
+    // Authentication.
+    authenticate(options: any) :Promise<any>;
+    logout(): void;
+    get(type: string): any;
+  
+    // Services.
+    service<T>(name: string): FeathersService<T>;
+    
+    configure(fn: () => void): FeathersApp;
+  }
+  
+  interface FeathersService<T> extends events.EventEmitter {
+    // REST interface.
+    find(params?: any): Promise<T>;
+    get(id: string, params?: any): Promise<T>;
+    create(data: T, params?: any): Promise<T>;
+    update(id: string, data: T, params?: any): Promise<T>;
+    patch(id: string, data: T, params?: any) : Promise<T>;
+    remove(id: string, params?: any): Promise<T>;
+  
+    // Realtime interface.
+    on(eventType: string, callback: (data: T) => void);
+    timeout?: number;
+  }
 
-interface FeathersService<T> extends events.EventEmitter {
-  // REST interface.
-  find(params?: any): Promise<T>;
-  get(id: string, params?: any): Promise<T>;
-  create(data: T, params?: any): Promise<T>;
-  update(id: string, data: T, params?:any): Promise<T>;
-  patch(id: string, data: T, params?:any) : Promise<T>;
-  remove(id: string, params?: any): Promise<T>;
+  interface FeathersFactory {
+    (): FeathersApp;
+    socketio: (socket: any) => any;
+    primus: (config: any, configurer: any | Function) => () => void;
+    rest: (base: string) => any;
+    hooks: () => any;
+    authentication: (config?: any) => () => void;
+    errors: any;
+  }
 
-  // Realtime interface.
-  on(eventType: string, callback: (data: T) => void);
-  timeout?: number;
+  const feathers: FeathersFactory;
+
+  export default feathers;
 }


### PR DESCRIPTION
### Summary
Solves https://github.com/feathersjs/feathers-client/issues/179 by adding a default export for the module. I'll expand on the `any` types in a future PR!