### PR TITLE
Allow feathers client to work in IE 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules
 
 lib/
 dist/
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,16 @@
         "@types/node": "8.0.7"
       }
     },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abab": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
@@ -1122,9 +1132,9 @@
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "defined": "1.0.0",
-        "JSONStream": "1.3.1",
         "through2": "2.0.3",
         "umd": "3.0.1"
       }
@@ -1158,6 +1168,7 @@
       "integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "assert": "1.4.1",
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
@@ -1179,7 +1190,6 @@
         "https-browserify": "1.0.0",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
-        "JSONStream": "1.3.1",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -2081,7 +2091,19 @@
         "cookie": "0.3.1",
         "debug": "2.6.8",
         "engine.io-parser": "2.1.1",
-        "uws": "0.14.5"
+        "uws": "0.14.5",
+        "ws": "2.3.1"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
+          "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
+          "requires": {
+            "safe-buffer": "5.0.1",
+            "ultron": "1.1.0"
+          }
+        }
       }
     },
     "engine.io-client": {
@@ -2098,8 +2120,20 @@
         "parsejson": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
+        "ws": "2.3.1",
         "xmlhttprequest-ssl": "1.5.3",
         "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
+          "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
+          "requires": {
+            "safe-buffer": "5.0.1",
+            "ultron": "1.1.0"
+          }
+        }
       }
     },
     "engine.io-parser": {
@@ -2189,8 +2223,12 @@
     "es6-object-assign": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
-      "dev": true
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
+    },
+    "es6-promise": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
     },
     "es6-set": {
       "version": "0.1.5",
@@ -2761,7 +2799,7 @@
       "integrity": "sha1-rdDtD1YsJGIijCLWiOEmHvX5blY=",
       "requires": {
         "debug": "2.6.8",
-        "feathers-errors": "2.9.1",
+        "feathers-errors": "2.9.2",
         "jwt-decode": "2.2.0"
       }
     },
@@ -2771,11 +2809,21 @@
       "integrity": "sha1-EcbyW1N3RamD6NYVUtfbiTLVN4I="
     },
     "feathers-errors": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/feathers-errors/-/feathers-errors-2.9.1.tgz",
-      "integrity": "sha512-YCpI7aw7s+qo9rNOQZ2lriB8VleDre2sZzZZLIODIqILATagPyfWgdLxmG9RVELS0JIXnK0spUxKBxof5uMj8A==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/feathers-errors/-/feathers-errors-2.9.2.tgz",
+      "integrity": "sha512-qwIX97bNW7+1tWVG073+omUA0rCYKJtTtwuzTrrvfrtdr8J8Dk1Fy4iaV9Fa6/YBD5AZu0lsplPE0iu4u/d4GQ==",
       "requires": {
-        "debug": "2.6.8"
+        "debug": "3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
+          "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "feathers-hooks": {
@@ -2794,7 +2842,7 @@
       "dev": true,
       "requires": {
         "feathers-commons": "0.8.7",
-        "feathers-errors": "2.9.1",
+        "feathers-errors": "2.9.2",
         "feathers-query-filters": "2.1.2",
         "uberproto": "1.2.0"
       }
@@ -2827,7 +2875,7 @@
       "requires": {
         "debug": "2.6.8",
         "feathers-commons": "0.8.7",
-        "feathers-errors": "2.9.1",
+        "feathers-errors": "2.9.2",
         "qs": "6.4.0"
       }
     },
@@ -2838,7 +2886,7 @@
       "requires": {
         "debug": "2.6.8",
         "feathers-commons": "0.8.7",
-        "feathers-errors": "2.9.1"
+        "feathers-errors": "2.9.2"
       }
     },
     "feathers-socketio": {
@@ -3846,14 +3894,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3862,6 +3902,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4537,10 +4585,10 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.5",
-        "JSONStream": "1.3.1",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -5078,16 +5126,6 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "jsprim": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
@@ -5535,6 +5573,7 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -5542,7 +5581,6 @@
         "detective": "4.5.0",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
-        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "2.3.3",
         "resolve": "1.3.3",
@@ -6557,8 +6595,7 @@
     "safe-buffer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-      "dev": true
+      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
     },
     "sauce-tunnel": {
       "version": "2.5.0",
@@ -6982,6 +7019,17 @@
         "readable-stream": "2.3.3"
       }
     },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
@@ -6997,17 +7045,6 @@
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         }
-      }
-    },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
   },
   "typings": "index.d.ts",
   "dependencies": {
+    "es6-object-assign": "^1.1.0",
+    "es6-promise": "^4.1.1",
     "feathers": "2.2.0",
     "feathers-authentication-client": "^0.3.1",
     "feathers-errors": "2.9.2",

--- a/src/client.js
+++ b/src/client.js
@@ -1,3 +1,5 @@
+import 'es6-object-assign/auto';
+import 'es6-promise/auto';
 import feathers from 'feathers/client';
 import hooks from 'feathers-hooks';
 import errors from 'feathers-errors';


### PR DESCRIPTION
Feathers client was not working in IE 11 due to use of Object.assign and Promise. I have put polyfills in for those and now it is working and all tests are still running correctly. This is pretty urgent for us for our live deployment. 
