### PR TITLE
Update TypeScript definition for service.patch

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare module 'feathers-client' {
     get(id: string, params?: any): Promise<T>;
     create(data: T, params?: any): Promise<T>;
     update(id: string, data: T, params?: any): Promise<T>;
-    patch(id: string, data: T, params?: any) : Promise<T>;
+    patch<K extends keyof T>(id: string, data:Pick<T, K>, params?: any) : Promise<T>;
     remove(id: string, params?: any): Promise<T>;
   
     // Realtime interface.


### PR DESCRIPTION
Similar to React's `setState`, the `patch` function should allow a partial object of a given type, but no extraneous keys thereafter.

Resource: https://github.com/developit/preact/blob/f7834ec9fb7848581c6fbc7833bcbe2f2db9fe61/src/preact.d.ts#L61